### PR TITLE
feat: add flow editor chat API and frontend

### DIFF
--- a/backend/app/agents/flow_chat_agent.py
+++ b/backend/app/agents/flow_chat_agent.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Sequence
+
+from pydantic import BaseModel
+
+from app.core.llm import LLMClient
+
+
+class ToolSpec(BaseModel):
+    """Specification for a callable tool."""
+
+    name: str
+    description: str | None = None
+    args_schema: type[BaseModel] | None = None
+    func: Callable[..., str]
+
+
+class FlowChatAgent:
+    """LLM-driven agent that can apply tools to modify a flow."""
+
+    def __init__(self, llm: LLMClient, tools: Sequence[ToolSpec] | None = None) -> None:
+        self.llm = llm
+        self.tools = {t.name: t for t in tools or []}
+
+    def process(self, flow: dict[str, Any], history: Sequence[dict[str, str]]) -> list[str]:
+        """Process conversation and return assistant responses."""
+
+        messages = list(history)
+        outputs: list[str] = []
+        tool_schemas = [t.args_schema for t in self.tools.values() if t.args_schema]
+        # Simple loop allowing multiple tool invocations
+        for _ in range(10):  # hard limit to avoid infinite loops
+            prompt = self._build_prompt(flow, messages)
+            result = self.llm.extract(prompt, tool_schemas)
+            content = result.get("content")
+            if content:
+                outputs.append(content)
+                messages.append({"role": "assistant", "content": content})
+            tool_calls = result.get("tool_calls") or []
+            if not tool_calls:
+                break
+            for call in tool_calls:
+                name = call.get("name")
+                args = call.get("arguments", {})
+                tool = self.tools.get(name)
+                if not tool:
+                    continue
+                tool_output = tool.func(**args)
+                outputs.append(tool_output)
+                messages.append({"role": "assistant", "content": tool_output})
+        return outputs
+
+    def _build_prompt(self, flow: dict[str, Any], history: Sequence[dict[str, str]]) -> str:
+        """Very small prompt builder combining flow and chat history."""
+
+        lines = ["You are a flow editing assistant."]
+        lines.append(f"Current flow: {flow}")
+        for m in history:
+            lines.append(f"{m['role']}: {m['content']}")
+        return "\n".join(lines)

--- a/backend/app/api/flow_chat.py
+++ b/backend/app/api/flow_chat.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Path
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.agents.flow_chat_agent import FlowChatAgent, ToolSpec
+from app.core.app_context import get_app_context
+from app.core.llm import LLMClient
+from app.db.models import FlowChatRole
+from app.db.session import get_db_session
+from app.services.flow_chat_service import FlowChatService
+
+router = APIRouter(prefix="/flows/{flow_id}/chat", tags=["flow_chat"])
+
+
+class SendMessageRequest(BaseModel):
+    content: str
+
+
+class ChatMessageResponse(BaseModel):
+    id: UUID
+    role: FlowChatRole
+    content: str
+    created_at: datetime
+
+
+def _build_agent(llm: LLMClient) -> FlowChatAgent:
+    # No concrete tools yet; placeholder for future expansion
+    tools: List[ToolSpec] = []
+    return FlowChatAgent(llm=llm, tools=tools)
+
+
+@router.post("/send", response_model=list[ChatMessageResponse])
+def send_message(
+    flow_id: UUID = Path(...),
+    req: SendMessageRequest | None = None,
+    session: Session = Depends(get_db_session),
+) -> list[ChatMessageResponse]:
+    if req is None:
+        raise HTTPException(status_code=400, detail="content required")
+    ctx = get_app_context()
+    if ctx.llm is None:  # pragma: no cover - safeguard
+        raise HTTPException(status_code=500, detail="LLM not configured")
+    service = FlowChatService(session, agent=_build_agent(ctx.llm))
+    msgs = service.send_user_message(flow_id, req.content)
+    return [
+        ChatMessageResponse(
+            id=m.id, role=m.role, content=m.content, created_at=m.created_at
+        )
+        for m in msgs
+    ]
+
+
+@router.get("/messages", response_model=list[ChatMessageResponse])
+def list_messages(
+    flow_id: UUID = Path(...), session: Session = Depends(get_db_session)
+) -> list[ChatMessageResponse]:
+    service = FlowChatService(session)
+    msgs = service.list_messages(flow_id)
+    return [
+        ChatMessageResponse(
+            id=m.id, role=m.role, content=m.content, created_at=m.created_at
+        )
+        for m in msgs
+    ]
+
+
+@router.get("/receive", response_model=ChatMessageResponse | None)
+def receive_latest(
+    flow_id: UUID = Path(...), session: Session = Depends(get_db_session)
+) -> ChatMessageResponse | None:
+    service = FlowChatService(session)
+    m = service.get_latest_assistant(flow_id)
+    if not m:
+        return None
+    return ChatMessageResponse(
+        id=m.id, role=m.role, content=m.content, created_at=m.created_at
+    )

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -51,6 +51,14 @@ class MessageStatus(str, Enum):
     failed = "failed"
 
 
+class FlowChatRole(str, Enum):
+    """Participant role in a flow editor chat."""
+
+    user = "user"
+    assistant = "assistant"
+    system = "system"
+
+
 # --- Base mixins
 
 
@@ -258,3 +266,14 @@ class MessageAttachment(Base, TimestampMixin):
     attachment_metadata: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
     message: Mapped[Message] = relationship(back_populates="attachments")
+
+
+class FlowChatMessage(Base, TimestampMixin):
+    """Stores messages exchanged in the flow editor chat."""
+
+    __tablename__ = "flow_chat_messages"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid7)
+    flow_id: Mapped[UUID] = mapped_column(ForeignKey("flows.id", ondelete="CASCADE"))
+    role: Mapped[FlowChatRole] = mapped_column(PgEnum(FlowChatRole, name="flow_chat_role"))
+    content: Mapped[str] = mapped_column(Text, nullable=False)

--- a/backend/app/router.py
+++ b/backend/app/router.py
@@ -5,12 +5,14 @@ from fastapi import APIRouter
 from app.api.admin import router as admin_router
 from app.api.chats import router as chats_router
 from app.api.flows import router as flows_router
+from app.api.flow_chat import router as flow_chat_router
 from app.whatsapp.router import router as whatsapp_router
 
 api_router = APIRouter()
 
 # Mount channel/feature routers here
 api_router.include_router(flows_router)
+api_router.include_router(flow_chat_router)
 api_router.include_router(whatsapp_router)
 api_router.include_router(admin_router)
 api_router.include_router(chats_router)

--- a/backend/app/services/flow_chat_service.py
+++ b/backend/app/services/flow_chat_service.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Sequence
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.agents.flow_chat_agent import FlowChatAgent
+from app.db.models import Flow, FlowChatMessage, FlowChatRole
+from app.db.repository import (
+    create_flow_chat_message,
+    get_latest_assistant_message,
+    list_flow_chat_messages,
+)
+
+
+class FlowChatService:
+    """Service layer for the flow editor chat."""
+
+    def __init__(self, session: Session, agent: FlowChatAgent | None = None) -> None:
+        self.session = session
+        self.agent = agent
+
+    # message listing
+    def list_messages(self, flow_id: UUID) -> Sequence[FlowChatMessage]:
+        return list_flow_chat_messages(self.session, flow_id)
+
+    def get_latest_assistant(self, flow_id: UUID) -> FlowChatMessage | None:
+        return get_latest_assistant_message(self.session, flow_id)
+
+    def send_user_message(self, flow_id: UUID, content: str) -> list[FlowChatMessage]:
+        if not self.agent:
+            raise RuntimeError("agent required to process messages")
+
+        create_flow_chat_message(
+            self.session, flow_id=flow_id, role=FlowChatRole.user, content=content
+        )
+        history = list_flow_chat_messages(self.session, flow_id)
+
+        flow = self.session.get(Flow, flow_id)
+        flow_def = flow.definition if flow else {}
+        history_dicts = [
+            {"role": msg.role.value, "content": msg.content} for msg in history
+        ]
+        responses = self.agent.process(flow_def, history_dicts)
+        saved: list[FlowChatMessage] = []
+        for text in responses:
+            saved.append(
+                create_flow_chat_message(
+                    self.session,
+                    flow_id=flow_id,
+                    role=FlowChatRole.assistant,
+                    content=text,
+                )
+            )
+        self.session.commit()
+        return saved

--- a/backend/tests/test_flow_chat_agent.py
+++ b/backend/tests/test_flow_chat_agent.py
@@ -1,0 +1,41 @@
+from typing import Any
+
+from app.agents.flow_chat_agent import FlowChatAgent, ToolSpec
+from app.core.llm import LLMClient
+
+
+class SeqLLM(LLMClient):
+    """Deterministic LLM returning pre-seeded results."""
+
+    def __init__(self, results: list[dict[str, Any]]) -> None:
+        self._results = results
+        self._i = 0
+
+    def extract(self, prompt: str, tools: list[type[object]]) -> dict[str, Any]:  # type: ignore[override]
+        if self._i < len(self._results):
+            res = self._results[self._i]
+            self._i += 1
+            return res
+        return {}
+
+
+def test_agent_executes_multiple_tool_calls() -> None:
+    added: list[str] = []
+
+    def add_node(node: str) -> str:
+        added.append(node)
+        return f"added {node}"
+
+    tools = [ToolSpec(name="add", func=add_node)]
+    llm = SeqLLM(
+        [
+            {"tool_calls": [{"name": "add", "arguments": {"node": "a"}}, {"name": "add", "arguments": {"node": "b"}}]},
+            {"content": "done"},
+        ]
+    )
+    agent = FlowChatAgent(llm=llm, tools=tools)
+    history = [{"role": "user", "content": "add two nodes"}]
+    responses = agent.process({}, history)
+
+    assert added == ["a", "b"]
+    assert responses[-1] == "done"

--- a/frontend/app/flows/[id]/page.tsx
+++ b/frontend/app/flows/[id]/page.tsx
@@ -44,7 +44,7 @@ export default function FlowDetailPage() {
                 <FlowExperience flow={flow} />
               </div>
               <div>
-                <FlowEditorChat />
+                <FlowEditorChat flowId={id} />
               </div>
             </div>
             <SubflowSection subflows={flow.subflows} />

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -91,6 +91,13 @@ export interface Message {
   provider_message_id?: string;
 }
 
+export interface FlowChatMessage {
+  id: string; // UUIDv7
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  created_at: string;
+}
+
 export interface ChatThread {
   id: string; // UUIDv7
   status: 'open' | 'closed' | 'archived';
@@ -232,8 +239,22 @@ export const api = {
     getExample: (): Promise<any> => 
       apiRequest('/flows/example/raw'),
     
-    getExampleCompiled: (): Promise<any> => 
+    getExampleCompiled: (): Promise<any> =>
       apiRequest('/flows/example/compiled'),
+  },
+
+  flowChat: {
+    send: (flowId: string, content: string): Promise<FlowChatMessage[]> =>
+      apiRequest(`/flows/${flowId}/chat/send`, {
+        method: 'POST',
+        body: JSON.stringify({ content }),
+      }),
+
+    list: (flowId: string): Promise<FlowChatMessage[]> =>
+      apiRequest(`/flows/${flowId}/chat/messages`),
+
+    receive: (flowId: string): Promise<FlowChatMessage | null> =>
+      apiRequest(`/flows/${flowId}/chat/receive`),
   },
 
   // Chat endpoints


### PR DESCRIPTION
## Summary
- add flow editor chat persistence and endpoints
- integrate flow edit chat with frontend components
- add flow chat agent and service with tool-call support
- enhance LangChain adapter to return content and multiple tool calls

## Testing
- `PYTHONPATH=backend pytest backend/tests/test_flow_chat_agent.py -q`
- `PYTHONPATH=backend pytest backend/tests -q` *(fails: multiple test failures)*
- `cd frontend && npm run lint` *(fails: eslint errors)*

------
https://chatgpt.com/codex/tasks/task_b_68aa298fb5488332b5ed0ac5abb80527